### PR TITLE
GTK: font is now a pango_font_description

### DIFF
--- a/modules/view/backends/gtk3/font.reds
+++ b/modules/view/backends/gtk3/font.reds
@@ -67,18 +67,22 @@ make-font: func [
 	font	[red-object!]
 	return: [handle!]
 	/local
-		values   [red-value!]
-		blk      [red-block!]
-		css      [c-string!]
-		hFont    [handle!]
-		int      [red-integer!]
+		values	[red-value!]
+		blk		[red-block!]
+		css		[c-string!]
+		hFont	[handle!]
+		int		[red-integer!]
+		style	[handle!]
+		widget	[handle!]
 ][
 	; release first
 	hFont: get-font-handle font
 	unless null? hFont [free-font-handle hFont]
 
-	css: css-font face font
-	hFont: as handle! css
+	hFont: font-description font
+
+	;style:	gtk_widget_get_style_context widget
+	;gtk_style_context_get [style "font" hFont null]
 
 	values: object/get-values font
 			
@@ -144,7 +148,7 @@ get-font-handle: func [
 free-font-handle: func [
 	hFont [handle!]
 ][
-	g_free hFont
+	pango_font_description_free hFont
 ]
 
 free-font: func [

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -615,6 +615,11 @@ cairo_font_extents_t!: alias struct! [
 			widget	[handle!]
 			fd		[handle!] 
 		]
+		gtk_widget_override_color: "gtk_widget_override_color" [
+			widget	[handle!]
+			state	[integer!]
+			color	[handle!] 
+		]
 		gtk_container_add: "gtk_container_add" [
 			container	[handle!]
 			widget		[handle!]

--- a/modules/view/backends/gtk3/gui.reds
+++ b/modules/view/backends/gtk3/gui.reds
@@ -29,6 +29,7 @@ red-face-id:	0
 _widget-id:		1
 gtk-fixed-id:	2
 red-timer-id:	3
+css-id:			4
 
 gtk-style-id:	0
 
@@ -185,7 +186,7 @@ get-child-from-xy: func [
 get-text-size: func [
 	face    [red-object!]
 	str		[red-string!]
-	font	[red-object!]
+	hFont	[handle!]
 	pair	[red-pair!]
 	return: [tagSIZE]
 	/local
@@ -195,7 +196,6 @@ get-text-size: func [
 		height	[integer!]
 		pl		[handle!]
 		size	[tagSIZE]
-		fd		[handle!]
 		df		[c-string!]
 ][
 	if null? pango-context [pango-context: gdk_pango_context_get]
@@ -210,21 +210,10 @@ get-text-size: func [
 
 	width: 0 height: 0
 
-	; @@ TO REMOVE since font-description manages directly none value for font
-	;fd: either TYPE_OF(font) = TYPE_NONE [ 
-	;	pango_font_description_from_string gtk-font
-	;][
-	;	font-description font
-	;]
-
-	; The lines above replaced with
-	fd: font-description font
-
 	pl: pango_layout_new pango-context
 	pango_layout_set_text pl text -1
-	pango_layout_set_font_description pl fd
+	pango_layout_set_font_description pl hFont
 	pango_layout_get_pixel_size pl :width :height
-	pango_font_description_free fd
 	g_object_unref pl
 
 	size/width: width
@@ -656,7 +645,10 @@ change-font: func [
 
 	provider: get-font-provider hWnd
 
-	css: as c-string! make-font face font
+	make-font face font
+
+	css: ""
+	css: css-font face font
 
 	;; DEBUG: print ["change-font ccs: " css lf]
 

--- a/modules/view/backends/platform.red
+++ b/modules/view/backends/platform.red
@@ -572,12 +572,7 @@ system/view/platform: context [
 		]
 		pair: as red-pair! stack/arguments
 		pair/header: TYPE_PAIR
-		
-		;GTK branch: gui/get-text-size face text hFont pair
-		#switch OS [
-			Linux [gui/get-text-size face text font pair]
-			#default [gui/get-text-size face text hFont pair]
-		]
+		gui/get-text-size face text hFont pair
 	]
 	
 	on-change-facet: routine [


### PR DESCRIPTION
* get-text-size in gui.red has the same signature tas macOS and windows
* platform.red is then as originally